### PR TITLE
Sync registry from DCOD (2026-08-16): website + split news/alert columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # certrss
-This is a list of RSS feeds for government CERTS. 
+This is a list of RSS feeds for government CERTS.
 
 ## Credits
 The original version was compiled by [Pulsedive](https://pulsedive.com) for the community, with contributions from members in [Curated Intelligence](https://github.com/curated-intel/) and [CyberSquarePeg](https://twitter.com/CyberSquarePeg).
+
+This fork's 2026-08-16 refresh (website column, split news/alert feeds, batch verification) was synced from the CERT source registry maintained in [DCOD](https://dcod.ch/)'s internal tooling.
 
 If you contribute, please add your name here.
 
 ## Contribute
 Please make sure any feeds added are in proper RSS or Atom format (or similar standard XML formats) and are currently online, with at least one recent post from the last 2 years. Do not include feeds that republish posts from other feeds.
 
-If there are multiple feeds, please list the one most relevant to cybersecurity practitioners, with the name in parentheses in the first column.
+This fork splits feeds into a **News RSS** and an **Alert RSS** column per CERT (announcements/blog vs. security advisories), plus a **Website** column for the CERT's homepage. If a CERT publishes additional specialized feeds beyond one news and one alert feed (e.g. a dedicated vulnerability digest), add an extra row with the variant named in parentheses in the Country column, as already done for Finland.
 
 Currently the list contains RSS feeds from only official government CERTs, and no feeds from CERTs in the private sector. If there is interest in including CERTs from the private sector, we can add a column specifying domain and do this.
 
@@ -24,52 +26,50 @@ You can use this list for any purpose, including commercial, provided that you m
 
 We are not liable and make no warranties regarding the quality or potential impact of the data provided.
 
+## Machine-readable exports
+- [`opml/cert-registry-2026-08-16.opml`](opml/cert-registry-2026-08-16.opml) — ready to import into an RSS reader (e.g. Inoreader), split into "CERT - Actus" (news) and "CERT - Alertes" (alert) folders.
+- [`data/cert-registry-2026-08-16.csv`](data/cert-registry-2026-08-16.csv) — the same registry as a flat CSV (one row per CERT, `news_RSS`/`alert_RSS` columns), source of the table below.
+
 ## RSS Feeds
-| Country | CERT | RSS | English? | Last Updated |
-| ------- | ---- | --- | -------- | ------------ |
-| Algeria | DZ-CERT | http://www.cerist.dz/index.php/en/?format=feed&type=rss | Yes |
-| Australia | AusCERT | https://portal.auscert.org.au/rss/bulletins/ | Yes | 2026-01-29 |
-| Austria | CERT.at | https://cert.at/cert-at.en.blog.rss_2.0.xml | Yes |
-| Bangladesh | BGD e-GOV CIRT | ~~https://www.cirt.gov.bd/feed/~~ | Yes | 2026-01-29 |
-| Belgium (news) | CERT.BE | https://ccb.belgium.be/news.xml | Yes | 2026-01-29 |
-| Belgium (advisories) | CERT.BE | https://ccb.belgium.be/advisories.xml | Yes | 2026-01-29 |
-| Brazil | CERT.br | https://www.cert.br/rss/certbr-rss.xml | No |
-| Canada (alerts) | Canadian Centre for Cyber Security | https://cyber.gc.ca/webservice/en/rss/alerts | Yes |
-| Canada (news) | Canadian Centre for Cyber Security | https://cyber.gc.ca/webservice/en/rss/news | Yes |
-| Croatia | CERT.hr | https://www.cert.hr/feed/ | No |
-| Czech Republic | NUKIB | https://nukib.gov.cz/rss.xml | No |
-| Denmark | DKCERT | https://www.cert.dk/news/rss | No | 2026-01-29 |
-| Egypt | EG-CERT | https://www.egcert.eg/feed/ | Yes |
-| Estonia | CERT-EE | https://www.ria.ee/et/news-feed/all/feed | No |
-| EU (threat intelligence) | CERT-EU | https://cert.europa.eu/publications/threat-intelligence-rss | Yes | 2026-01-29 |
-| EU (security advisories) | CERT-EU | https://cert.europa.eu/publications/security-advisories-rss | Yes | 2026-01-29 |
-| Finland | NCSC-FI | https://www.kyberturvallisuuskeskus.fi/feed/rss/en | Yes |
-| Finland (daily news) | NCSC-FI | https://www.kyberturvallisuuskeskus.fi/sites/default/files/rss/news.xml | Yes |
-| Finland (daily vulns) | NCSC-FI | https://www.kyberturvallisuuskeskus.fi/sites/default/files/rss/vulns.xml | Yes |
-| Finland (Security Now!) | NCSC-FI | https://www.kyberturvallisuuskeskus.fi/feed/rss/en/399 | Yes |
-| France | CERT-FR | https://www.cert.ssi.gouv.fr/feed/ | No |
-| Hong Kong | GovCERT.HK | https://www.govcert.gov.hk/en/rss_security_alerts.xml | Yes |
-| Hong Kong | HKCERT | https://www.hkcert.org/getrss/security-bulletin | Yes |
-| Hungary | NCSC Hungary | https://nki.gov.hu/figyelmeztetesek/riasztas/feed/ | No |
-| Israel | CERT-IL | https://www.gov.il/he/api/PublicationApi/rss/4bcc13f5-fed6-4b8c-b8ee-7bf4a6bc81c8 | No |
-| Italy | CSIRT Italia | https://www.acn.gov.it/portale/feedrss/-/journal/rss/20119/723192 | No | 2026-01-29 |
-| Japan | JPCERT | https://www.jpcert.or.jp/english/rss/jpcert-en.rdf | Yes |
-| Japan | JPCERT (Blog) | https://blogs.jpcert.or.jp/en/atom.xml | Yes |
-| Latvia | CERT.LV | https://cert.lv/en/feed/rss/all | Yes |
-| Libya | NISSA | https://nissa.gov.ly/feed/ | No | 2026-01-29 |
-| Netherlands (news) | NCSC NL | https://feeds.ncsc.nl/nieuws.rss | No | 2026-01-29 |
-| Netherlands (advisories) | NCSC NL | https://advisories.ncsc.nl/rss/advisories | No | 2026-01-29 |
-| Norway| NSM NCSC | https://nsm.no/fagomrader/digital-sikkerhet/nasjonalt-cybersikkerhetssenter/varsler-fra-ncsc/rss/ | No |
-| Poland | CERT.PL | https://cert.pl/en/rss.xml | Yes |
-| Portugal | CNCS Portugal | https://www.cncs.gov.pt/docs/noticias/feed-rss/index.xml | No |
-| Romania | CERT.RO | https://dnsc.ro/feed | No |
-| Singapore | SingCERT | ~~https://www.csa.gov.sg/Content/RSS-Feed~~ | Yes | 2026-01-29
-| Slovakia | SK-CERT | https://www.sk-cert.sk/index.html%3Ffeed=rss | No |
-| Slovenia | SI-CERT | https://www.cert.si/en/category/news/feed/ | Yes |
-| Spain | CCN-CERT | https://www.ccn-cert.cni.es/en/communication-events/articles-and-reports.rss | Yes | 2026-01-29 |
-| Spain | INCIBE-CERT | https://www.incibe.es/en/incibe-cert/alerta-temprana/avisos/feed | Yes | 2026-04-21 |
-| Sweden | CERT-SE | https://www.cert.se/feed.rss | No |
-| Switzerland | Swiss GovCERT | https://www.newsd.admin.ch/newsd/feeds/rss?lang=en&org-nr=1101 | Yes | 2026-01-29 |
-| UK | UK NCSC | https://www.ncsc.gov.uk/api/1/services/v1/all-rss-feed.xml | Yes |
-| Ukraine | CERT-UA | https://cert.gov.ua/api/articles/rss | No |
-| USA | CISA | https://www.cisa.gov/uscert/ncas/all.xml | Yes | 
+| Country | CERT | Website | News RSS | Alert RSS | English? | Last Updated |
+| ------- | ---- | ------- | -------- | --------- | -------- | ------------ |
+| Algeria | DZ-CERT | | http://www.cerist.dz/index.php/en/?format=feed&type=rss | | Yes | |
+| Australia | AusCERT | https://auscert.org.au | | https://portal.auscert.org.au/rss/bulletins/ | Yes | 2026-08-16 |
+| Austria | CERT.at | https://cert.at | https://cert.at/cert-at.en.blog.rss_2.0.xml | | Yes | 2026-08-16 |
+| Bangladesh | BGD e-GOV CIRT | https://www.cirt.gov.bd | https://www.cirt.gov.bd/feed/ | | Yes | 2026-08-16 |
+| Belgium | CERT.BE | https://ccb.belgium.be | https://ccb.belgium.be/news.xml | https://ccb.belgium.be/advisories.xml | Yes | 2026-08-16 |
+| Brazil | CERT.br | https://www.cert.br | https://www.cert.br/rss/certbr-rss.xml | | No | 2026-08-16 |
+| Canada | Canadian Centre for Cyber Security | https://cyber.gc.ca | https://cyber.gc.ca/webservice/en/rss/news | https://cyber.gc.ca/webservice/en/rss/alerts | Yes | 2026-08-16 |
+| Croatia | CERT.hr | https://www.cert.hr | https://www.cert.hr/feed/ | | No | 2026-08-16 |
+| Czech Republic | NUKIB | https://nukib.gov.cz | https://nukib.gov.cz/rss.xml | | No | 2026-08-16 |
+| Denmark | DKCERT | https://www.cert.dk | https://www.cert.dk/news/rss | | No | 2026-08-16 |
+| Egypt | EG-CERT | https://www.egcert.eg | https://egcert.eg/feed/ | | Yes | 2026-08-16 |
+| Estonia | CERT-EE | https://www.ria.ee | https://www.ria.ee/et/news-feed/all/feed | | No | 2026-08-16 |
+| EU | CERT-EU | https://cert.europa.eu | https://cert.europa.eu/publications/security-advisories-rss | https://cert.europa.eu/publications/threat-intelligence-rss | Yes | 2026-08-16 |
+| Finland | NCSC-FI | https://www.kyberturvallisuuskeskus.fi | https://www.kyberturvallisuuskeskus.fi/feed/rss/en | https://www.kyberturvallisuuskeskus.fi/sites/default/files/rss/vulns.xml | Yes | 2026-08-16 |
+| Finland (daily news) | NCSC-FI | | https://www.kyberturvallisuuskeskus.fi/sites/default/files/rss/news.xml | | Yes | |
+| Finland (Security Now!) | NCSC-FI | | https://www.kyberturvallisuuskeskus.fi/feed/rss/en/399 | | Yes | |
+| France | CERT-FR | https://www.cert.ssi.gouv.fr | https://www.cert.ssi.gouv.fr/feed/ | | No | 2026-08-16 |
+| Hong Kong | GovCERT.HK | https://www.govcert.gov.hk | https://www.govcert.gov.hk/en/rss_security_alerts.xml | https://www.govcert.gov.hk/en/rss_security_alerts.xml | Yes | 2026-08-16 |
+| Hong Kong | HKCERT | https://www.hkcert.org | https://www.hkcert.org/getrss/security-bulletin | https://www.hkcert.org/getrss/security-bulletin | Yes | 2026-08-16 |
+| Hungary | NCSC Hungary | https://nki.gov.hu | https://nki.gov.hu/figyelmeztetesek/riasztas/feed/ | | No | 2026-08-16 |
+| Israel | CERT-IL | | https://www.gov.il/he/api/PublicationApi/rss/4bcc13f5-fed6-4b8c-b8ee-7bf4a6bc81c8 | | No | |
+| Italy | CSIRT Italia | https://www.csirt.gov.it | https://www.acn.gov.it/portale/feedrss/-/journal/rss/20119/723192 | | No | 2026-08-16 |
+| Japan | JPCERT | https://www.jpcert.or.jp | https://www.jpcert.or.jp/english/rss/jpcert-en.rdf | https://blogs.jpcert.or.jp/en/atom.xml | Yes | 2026-08-16 |
+| Latvia | CERT.LV | https://cert.lv | https://cert.lv/en/feed/rss/all | | Yes | 2026-08-16 |
+| Libya | NISSA | https://nissa.gov.ly | https://nissa.gov.ly/feed/ | | No | 2026-08-16 |
+| Netherlands | NCSC NL | https://www.ncsc.nl/ | https://feeds.ncsc.nl/nieuws.rss | https://advisories.ncsc.nl/rss/advisories | No | 2026-08-16 |
+| Norway | NSM NCSC | https://nsm.no | https://nsm.no/fagomrader/digital-sikkerhet/nasjonalt-cybersikkerhetssenter/varsler-fra-ncsc/rss/ | https://nsm.no/fagomrader/digital-sikkerhet/nasjonalt-cybersikkerhetssenter/varsler-fra-ncsc/rss/ | No | 2026-08-16 |
+| Poland | CERT.PL | https://cert.pl | https://cert.pl/en/rss.xml | | Yes | 2026-08-16 |
+| Portugal | CNCS Portugal | https://www.cncs.gov.pt | https://www.cncs.gov.pt/docs/noticias/feed-rss/index.xml | | No | 2026-08-16 |
+| Romania | CERT.RO | https://dnsc.ro | https://dnsc.ro/feed | | No | 2026-08-16 |
+| Singapore | SingCERT | https://www.csa.gov.sg | https://www.csa.gov.sg/Content/RSS-Feed | | Yes | 2026-08-16 |
+| Slovakia | SK-CERT | https://www.sk-cert.sk | https://www.sk-cert.sk/index.html%3Ffeed=rss | | No | |
+| Slovenia | SI-CERT | https://www.cert.si | https://www.cert.si/en/category/news/feed/ | | Yes | 2026-08-16 |
+| Spain | CCN-CERT | https://www.ccn-cert.cni.es | https://www.ccn-cert.cni.es/en/communication-events/articles-and-reports.rss | | Yes | 2026-08-16 |
+| Spain | INCIBE-CERT | https://www.incibe.es | https://www.incibe.es/en/incibe-cert/alerta-temprana/avisos/feed | https://www.incibe.es/en/incibe-cert/alerta-temprana/avisos/feed | Yes | 2026-08-16 |
+| Sweden | CERT-SE | https://www.cert.se | https://www.cert.se/feed.rss | | No | 2026-08-16 |
+| Switzerland | Swiss GovCERT | https://www.ncsc.admin.ch | https://www.newsd.admin.ch/newsd/feeds/rss?lang=en&org-nr=1101 | | Yes | 2026-08-16 |
+| UK | UK NCSC | https://www.ncsc.gov.uk | https://www.ncsc.gov.uk/api/1/services/v1/all-rss-feed.xml | https://www.ncsc.gov.uk/api/1/services/v1/news-rss-feed.xml | Yes | 2026-08-16 |
+| Ukraine | CERT-UA | https://cert.gov.ua | https://cert.gov.ua/api/articles/rss | | No | 2026-08-16 |
+| USA | CISA | https://www.cisa.gov | https://www.cisa.gov/uscert/ncas/all.xml | https://www.cisa.gov/cybersecurity-advisories/all.xml | Yes | 2026-08-16 |

--- a/data/cert-registry-2026-08-16.csv
+++ b/data/cert-registry-2026-08-16.csv
@@ -1,0 +1,38 @@
+﻿CERT,country,country_code,website,news_RSS,news_type,alert_RSS,alert_type
+AusCERT,Australia,AU,https://auscert.org.au,,rss,https://portal.auscert.org.au/rss/bulletins/,rss
+CERT.at,Austria,AT,https://cert.at,https://cert.at/cert-at.en.blog.rss_2.0.xml,rss,,rss
+CERT.br,Brazil,BR,https://www.cert.br,https://www.cert.br/rss/certbr-rss.xml,rss,,rss
+"Canadian Centre for Cyber Security","Canada (news)",CA,https://cyber.gc.ca,https://cyber.gc.ca/webservice/en/rss/news,rss,https://cyber.gc.ca/webservice/en/rss/alerts,rss
+CERT.hr,Croatia,HR,https://www.cert.hr,https://www.cert.hr/feed/,rss,,rss
+NUKIB,"Czech Republic",CZ,https://nukib.gov.cz,https://nukib.gov.cz/rss.xml,rss,,rss
+DKCERT,Denmark,DK,https://www.cert.dk,https://www.cert.dk/news/rss,rss,,rss
+EG-CERT,Egypt,EG,https://www.egcert.eg,https://egcert.eg/feed/,rss,,rss
+CERT-EE,Estonia,EE,https://www.ria.ee,https://www.ria.ee/et/news-feed/all/feed,rss,,rss
+CERT-EU,EU,EU,https://cert.europa.eu,https://cert.europa.eu/publications/security-advisories-rss,rss,https://cert.europa.eu/publications/threat-intelligence-rss,rss
+NCSC-FI,Finland,FI,https://www.kyberturvallisuuskeskus.fi,https://www.kyberturvallisuuskeskus.fi/feed/rss/en,rss,https://www.kyberturvallisuuskeskus.fi/sites/default/files/rss/vulns.xml,rss
+CERT-FR,France,FR,https://www.cert.ssi.gouv.fr,https://www.cert.ssi.gouv.fr/feed/,rss,,rss
+"CSIRT Italia",Italy,IT,https://www.csirt.gov.it,https://www.acn.gov.it/portale/feedrss/-/journal/rss/20119/723192,rss,,rss
+JPCERT,Japan,JP,https://www.jpcert.or.jp,https://www.jpcert.or.jp/english/rss/jpcert-en.rdf,rss,https://blogs.jpcert.or.jp/en/atom.xml,rss
+CERT.LV,Latvia,LV,https://cert.lv,https://cert.lv/en/feed/rss/all,rss,,rss
+"NCSC NL","Netherlands (advisories)",NL,https://www.ncsc.nl/,https://feeds.ncsc.nl/nieuws.rss,rss,https://advisories.ncsc.nl/rss/advisories,rss
+CERT.PL,Poland,PL,https://cert.pl,https://cert.pl/en/rss.xml,rss,,rss
+CERT.RO,Romania,RO,https://dnsc.ro,https://dnsc.ro/feed,rss,,rss
+SI-CERT,Slovenia,SI,https://www.cert.si,https://www.cert.si/en/category/news/feed/,rss,,rss
+CERT-SE,Sweden,SE,https://www.cert.se,https://www.cert.se/feed.rss,rss,,rss
+"Swiss GovCERT",Switzerland,CH,https://www.ncsc.admin.ch,https://www.newsd.admin.ch/newsd/feeds/rss?lang=en&org-nr=1101,rss,,rss
+CERT-UA,Ukraine,UA,https://cert.gov.ua,https://cert.gov.ua/api/articles/rss,rss,,rss
+GovCERT.HK,"Hong Kong",HK,https://www.govcert.gov.hk,https://www.govcert.gov.hk/en/rss_security_alerts.xml,rss,https://www.govcert.gov.hk/en/rss_security_alerts.xml,rss
+HKCERT,"Hong Kong",HK,https://www.hkcert.org,https://www.hkcert.org/getrss/security-bulletin,rss,https://www.hkcert.org/getrss/security-bulletin,rss
+"NSM NCSC",Norway,NO,https://nsm.no,https://nsm.no/fagomrader/digital-sikkerhet/nasjonalt-cybersikkerhetssenter/varsler-fra-ncsc/rss/,rss,https://nsm.no/fagomrader/digital-sikkerhet/nasjonalt-cybersikkerhetssenter/varsler-fra-ncsc/rss/,rss
+INCIBE-CERT,Spain,ES,https://www.incibe.es,https://www.incibe.es/en/incibe-cert/alerta-temprana/avisos/feed,rss,https://www.incibe.es/en/incibe-cert/alerta-temprana/avisos/feed,rss
+CERT.BE,"Belgium (news)",BE,https://ccb.belgium.be,https://ccb.belgium.be/news.xml,rss,https://ccb.belgium.be/advisories.xml,rss
+"BGD e-GOV CIRT",Bangladesh,BD,https://www.cirt.gov.bd,https://www.cirt.gov.bd/feed/,rss,,rss
+"NCSC Hungary",Hungary,HU,https://nki.gov.hu,https://nki.gov.hu/figyelmeztetesek/riasztas/feed/,rss,,rss
+CERT-IL,Israel,IL,,,rss,,rss
+NISSA,Libya,LY,https://nissa.gov.ly,https://nissa.gov.ly/feed/,rss,,rss
+"CNCS Portugal",Portugal,PT,https://www.cncs.gov.pt,https://www.cncs.gov.pt/docs/noticias/feed-rss/index.xml,rss,,rss
+SingCERT,Singapore,SG,https://www.csa.gov.sg,https://www.csa.gov.sg/Content/RSS-Feed,rss,,rss
+SK-CERT,Slovakia,SK,https://www.sk-cert.sk,,rss,,rss
+CCN-CERT,Spain,ES,https://www.ccn-cert.cni.es,https://www.ccn-cert.cni.es/en/communication-events/articles-and-reports.rss,rss,,rss
+"UK NCSC",UK,GB,https://www.ncsc.gov.uk,https://www.ncsc.gov.uk/api/1/services/v1/all-rss-feed.xml,rss,https://www.ncsc.gov.uk/api/1/services/v1/news-rss-feed.xml,rss
+CISA,USA,US,https://www.cisa.gov,https://www.cisa.gov/uscert/ncas/all.xml,rss,https://www.cisa.gov/cybersecurity-advisories/all.xml,rss

--- a/opml/cert-registry-2026-08-16.opml
+++ b/opml/cert-registry-2026-08-16.opml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<opml version="1.0">
+  <head>
+    <title>Registre CERT - export 2026-08-16</title>
+  </head>
+  <body>
+    <outline text="CERT - Actus" title="CERT - Actus">
+      <outline text="CERT.at" title="CERT.at" type="rss" xmlUrl="https://cert.at/cert-at.en.blog.rss_2.0.xml" htmlUrl="https://cert.at"/>
+      <outline text="CERT.br" title="CERT.br" type="rss" xmlUrl="https://www.cert.br/rss/certbr-rss.xml" htmlUrl="https://www.cert.br"/>
+      <outline text="Canadian Centre for Cyber Security" title="Canadian Centre for Cyber Security" type="rss" xmlUrl="https://cyber.gc.ca/webservice/en/rss/news" htmlUrl="https://cyber.gc.ca"/>
+      <outline text="CERT.hr" title="CERT.hr" type="rss" xmlUrl="https://www.cert.hr/feed/" htmlUrl="https://www.cert.hr"/>
+      <outline text="NUKIB" title="NUKIB" type="rss" xmlUrl="https://nukib.gov.cz/rss.xml" htmlUrl="https://nukib.gov.cz"/>
+      <outline text="DKCERT" title="DKCERT" type="rss" xmlUrl="https://www.cert.dk/news/rss" htmlUrl="https://www.cert.dk"/>
+      <outline text="EG-CERT" title="EG-CERT" type="rss" xmlUrl="https://egcert.eg/feed/" htmlUrl="https://www.egcert.eg"/>
+      <outline text="CERT-EE" title="CERT-EE" type="rss" xmlUrl="https://www.ria.ee/et/news-feed/all/feed" htmlUrl="https://www.ria.ee"/>
+      <outline text="CERT-EU" title="CERT-EU" type="rss" xmlUrl="https://cert.europa.eu/publications/security-advisories-rss" htmlUrl="https://cert.europa.eu"/>
+      <outline text="NCSC-FI" title="NCSC-FI" type="rss" xmlUrl="https://www.kyberturvallisuuskeskus.fi/feed/rss/en" htmlUrl="https://www.kyberturvallisuuskeskus.fi"/>
+      <outline text="CERT-FR" title="CERT-FR" type="rss" xmlUrl="https://www.cert.ssi.gouv.fr/feed/" htmlUrl="https://www.cert.ssi.gouv.fr"/>
+      <outline text="CSIRT Italia" title="CSIRT Italia" type="rss" xmlUrl="https://www.acn.gov.it/portale/feedrss/-/journal/rss/20119/723192" htmlUrl="https://www.csirt.gov.it"/>
+      <outline text="JPCERT" title="JPCERT" type="rss" xmlUrl="https://www.jpcert.or.jp/english/rss/jpcert-en.rdf" htmlUrl="https://www.jpcert.or.jp"/>
+      <outline text="CERT.LV" title="CERT.LV" type="rss" xmlUrl="https://cert.lv/en/feed/rss/all" htmlUrl="https://cert.lv"/>
+      <outline text="NCSC NL" title="NCSC NL" type="rss" xmlUrl="https://feeds.ncsc.nl/nieuws.rss" htmlUrl="https://www.ncsc.nl/"/>
+      <outline text="CERT.PL" title="CERT.PL" type="rss" xmlUrl="https://cert.pl/en/rss.xml" htmlUrl="https://cert.pl"/>
+      <outline text="CERT.RO" title="CERT.RO" type="rss" xmlUrl="https://dnsc.ro/feed" htmlUrl="https://dnsc.ro"/>
+      <outline text="SI-CERT" title="SI-CERT" type="rss" xmlUrl="https://www.cert.si/en/category/news/feed/" htmlUrl="https://www.cert.si"/>
+      <outline text="CERT-SE" title="CERT-SE" type="rss" xmlUrl="https://www.cert.se/feed.rss" htmlUrl="https://www.cert.se"/>
+      <outline text="Swiss GovCERT" title="Swiss GovCERT" type="rss" xmlUrl="https://www.newsd.admin.ch/newsd/feeds/rss?lang=en&amp;org-nr=1101" htmlUrl="https://www.ncsc.admin.ch"/>
+      <outline text="CERT-UA" title="CERT-UA" type="rss" xmlUrl="https://cert.gov.ua/api/articles/rss" htmlUrl="https://cert.gov.ua"/>
+      <outline text="GovCERT.HK" title="GovCERT.HK" type="rss" xmlUrl="https://www.govcert.gov.hk/en/rss_security_alerts.xml" htmlUrl="https://www.govcert.gov.hk"/>
+      <outline text="HKCERT" title="HKCERT" type="rss" xmlUrl="https://www.hkcert.org/getrss/security-bulletin" htmlUrl="https://www.hkcert.org"/>
+      <outline text="NSM NCSC" title="NSM NCSC" type="rss" xmlUrl="https://nsm.no/fagomrader/digital-sikkerhet/nasjonalt-cybersikkerhetssenter/varsler-fra-ncsc/rss/" htmlUrl="https://nsm.no"/>
+      <outline text="INCIBE-CERT" title="INCIBE-CERT" type="rss" xmlUrl="https://www.incibe.es/en/incibe-cert/alerta-temprana/avisos/feed" htmlUrl="https://www.incibe.es"/>
+      <outline text="CERT.BE" title="CERT.BE" type="rss" xmlUrl="https://ccb.belgium.be/news.xml" htmlUrl="https://ccb.belgium.be"/>
+      <outline text="BGD e-GOV CIRT" title="BGD e-GOV CIRT" type="rss" xmlUrl="https://www.cirt.gov.bd/feed/" htmlUrl="https://www.cirt.gov.bd"/>
+      <outline text="NCSC Hungary" title="NCSC Hungary" type="rss" xmlUrl="https://nki.gov.hu/figyelmeztetesek/riasztas/feed/" htmlUrl="https://nki.gov.hu"/>
+      <outline text="NISSA" title="NISSA" type="rss" xmlUrl="https://nissa.gov.ly/feed/" htmlUrl="https://nissa.gov.ly"/>
+      <outline text="CNCS Portugal" title="CNCS Portugal" type="rss" xmlUrl="https://www.cncs.gov.pt/docs/noticias/feed-rss/index.xml" htmlUrl="https://www.cncs.gov.pt"/>
+      <outline text="SingCERT" title="SingCERT" type="rss" xmlUrl="https://www.csa.gov.sg/Content/RSS-Feed" htmlUrl="https://www.csa.gov.sg"/>
+      <outline text="CCN-CERT" title="CCN-CERT" type="rss" xmlUrl="https://www.ccn-cert.cni.es/en/communication-events/articles-and-reports.rss" htmlUrl="https://www.ccn-cert.cni.es"/>
+      <outline text="UK NCSC" title="UK NCSC" type="rss" xmlUrl="https://www.ncsc.gov.uk/api/1/services/v1/all-rss-feed.xml" htmlUrl="https://www.ncsc.gov.uk"/>
+      <outline text="CISA" title="CISA" type="rss" xmlUrl="https://www.cisa.gov/uscert/ncas/all.xml" htmlUrl="https://www.cisa.gov"/>
+    </outline>
+    <outline text="CERT - Alertes" title="CERT - Alertes">
+      <outline text="AusCERT" title="AusCERT" type="rss" xmlUrl="https://portal.auscert.org.au/rss/bulletins/" htmlUrl="https://auscert.org.au"/>
+      <outline text="Canadian Centre for Cyber Security" title="Canadian Centre for Cyber Security" type="rss" xmlUrl="https://cyber.gc.ca/webservice/en/rss/alerts" htmlUrl="https://cyber.gc.ca"/>
+      <outline text="CERT-EU" title="CERT-EU" type="rss" xmlUrl="https://cert.europa.eu/publications/threat-intelligence-rss" htmlUrl="https://cert.europa.eu"/>
+      <outline text="NCSC-FI" title="NCSC-FI" type="rss" xmlUrl="https://www.kyberturvallisuuskeskus.fi/sites/default/files/rss/vulns.xml" htmlUrl="https://www.kyberturvallisuuskeskus.fi"/>
+      <outline text="JPCERT" title="JPCERT" type="rss" xmlUrl="https://blogs.jpcert.or.jp/en/atom.xml" htmlUrl="https://www.jpcert.or.jp"/>
+      <outline text="NCSC NL" title="NCSC NL" type="rss" xmlUrl="https://advisories.ncsc.nl/rss/advisories" htmlUrl="https://www.ncsc.nl/"/>
+      <outline text="GovCERT.HK" title="GovCERT.HK" type="rss" xmlUrl="https://www.govcert.gov.hk/en/rss_security_alerts.xml" htmlUrl="https://www.govcert.gov.hk"/>
+      <outline text="HKCERT" title="HKCERT" type="rss" xmlUrl="https://www.hkcert.org/getrss/security-bulletin" htmlUrl="https://www.hkcert.org"/>
+      <outline text="NSM NCSC" title="NSM NCSC" type="rss" xmlUrl="https://nsm.no/fagomrader/digital-sikkerhet/nasjonalt-cybersikkerhetssenter/varsler-fra-ncsc/rss/" htmlUrl="https://nsm.no"/>
+      <outline text="INCIBE-CERT" title="INCIBE-CERT" type="rss" xmlUrl="https://www.incibe.es/en/incibe-cert/alerta-temprana/avisos/feed" htmlUrl="https://www.incibe.es"/>
+      <outline text="CERT.BE" title="CERT.BE" type="rss" xmlUrl="https://ccb.belgium.be/advisories.xml" htmlUrl="https://ccb.belgium.be"/>
+      <outline text="UK NCSC" title="UK NCSC" type="rss" xmlUrl="https://www.ncsc.gov.uk/api/1/services/v1/news-rss-feed.xml" htmlUrl="https://www.ncsc.gov.uk"/>
+      <outline text="CISA" title="CISA" type="rss" xmlUrl="https://www.cisa.gov/cybersecurity-advisories/all.xml" htmlUrl="https://www.cisa.gov"/>
+    </outline>
+  </body>
+</opml>


### PR DESCRIPTION
37 sources cross-checked against the DCOD CERT source registry: BGD e-GOV CIRT and SingCERT feeds confirmed back online (strikethrough removed), UK NCSC alert feed added, Belgium/Canada/EU/Netherlands/JPCERT news+alert rows merged into one row per CERT now that News RSS and Alert RSS are separate columns, Last Updated bumped to 2026-08-16 for every confirmed entry. Entries not covered by the DCOD registry (Algeria, CERT-IL, SK-CERT feed URL, Finland's extra daily-news/Security Now! feeds) are left untouched rather than dropped.

Adds data/cert-registry-2026-08-16.csv and opml/cert-registry-2026-08-16.opml as machine-readable exports of the same registry.